### PR TITLE
Don't set state to None

### DIFF
--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -114,8 +114,8 @@ def load_table_cache(config):
 
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def persist_lines(config, lines, table_cache=None) -> None:
-    state = None
-    flushed_state = None
+    state = {}
+    flushed_state = {}
     schemas = {}
     key_properties = {}
     validators = {}


### PR DESCRIPTION
Both `state` and `flushed_state` are expected to be dictionaries once they're passed to the `flush_streams` function ([link](https://github.com/dsaxton-1password/pipelinewise-target-redshift/blob/master/target_redshift/__init__.py#L189)), otherwise we can hit this error:

```
Traceback (most recent call last):
  File "/meltano/.meltano/loaders/target-redshift/venv/bin/target-redshift", line 8, in <module>
    sys.exit(main())
  File "/meltano/.meltano/loaders/target-redshift/venv/lib/python3.8/site-packages/target_redshift/__init__.py", line 452, in main
    persist_lines(config, singer_messages, table_cache)
  File "/meltano/.meltano/loaders/target-redshift/venv/lib/python3.8/site-packages/target_redshift/__init__.py", line 189, in persist_lines
    flushed_state = flush_streams(
  File "/meltano/.meltano/loaders/target-redshift/venv/lib/python3.8/site-packages/target_redshift/__init__.py", line 335, in flush_streams
    if stream in state.get('bookmarks', {}):
AttributeError: 'NoneType' object has no attribute 'get'
```